### PR TITLE
fix: update Ingress rule to use networking.k8s.io/v1 API

### DIFF
--- a/basic/jupyter-ingress.yaml
+++ b/basic/jupyter-ingress.yaml
@@ -1,4 +1,4 @@
-apiVersion: networking.k8s.io/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: jupyter-ingress
@@ -8,6 +8,9 @@ spec:
     http:
       paths:
       - path: /
+        pathType: Prefix
         backend:
-          serviceName: proxy-public
-          servicePort: 80
+          service:
+            name: proxy-public
+            port:
+              number: 80


### PR DESCRIPTION
`basic/jupyter-ingress.yaml` is being rejected due to using `networking.k8s.io/v1beta` which is deprecated. 
Must upgrade to v1.